### PR TITLE
Remove Uniform Initialization From Input Initializer List

### DIFF
--- a/include/Input.h
+++ b/include/Input.h
@@ -19,7 +19,8 @@ namespace Gunship
 	public:
 		struct MouseCoord
 		{
-			int x, y;
+			int x = 0;
+			int y = 0;
 		};
 
 		typedef std::vector< SDL_Scancode > KeyEvents;

--- a/source/Input.cpp
+++ b/source/Input.cpp
@@ -8,9 +8,7 @@ namespace Gunship
 	static const float AXIS_MAX = 32768.0f; ///< The maximum value that SDL2 returns for a joystick's position.
 
 	Input::Input()
-		: _mouseMovement{ 0, 0 },
-		  _mousePos{ 0, 0 },
-		  _exit( false )
+		: _exit( false )
 	{
 		// initialize joysticks and whatnot
 		if ( SDL_NumJoysticks() > 0 )


### PR DESCRIPTION
- VS 2013 doesn't support using uniform initialization within an initializer list, so I removed it.
